### PR TITLE
fix(docker): use "redis" schema in redis url

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--color
+--format documentation
+--require spec_helper

--- a/lib/travis/config/docker.rb
+++ b/lib/travis/config/docker.rb
@@ -23,7 +23,7 @@ module Travis
         end
 
         def redis
-          { url: ENV['REDIS_PORT'] } if ENV['REDIS_PORT']
+          { url: ENV['REDIS_PORT'].sub(%r(\Atcp(?=://)), 'redis') } if ENV['REDIS_PORT']
         end
 
         def parse(url)

--- a/spec/travis/config/docker_spec.rb
+++ b/spec/travis/config/docker_spec.rb
@@ -31,7 +31,7 @@ describe Travis::Config::Docker do
     before { ENV['REDIS_PORT'] = 'tcp://172.17.0.7:6379' }
 
     it 'loads the port to redis.url' do
-      expect(config.redis).to eq({ url: 'tcp://172.17.0.7:6379' })
+      expect(config.redis).to eq({ url: 'redis://172.17.0.7:6379' })
     end
   end
 end


### PR DESCRIPTION
redis gem (at least version 3.2.0) does not work if url is specified as `tcp://example.com:4567`. Schema has to be change to redis, e.g. `redis://example.com:4567`
