### PR TITLE
Move the logs_database default to the config, outside of the loader

### DIFF
--- a/lib/travis/config.rb
+++ b/lib/travis/config.rb
@@ -17,7 +17,9 @@ module Travis
       end
 
       def load(*names)
-        new(load_from(*names))
+        config = load_from(*names)
+        config = normalize(config)
+        new(config)
       end
 
       private
@@ -31,6 +33,11 @@ module Travis
         def loaders(*names)
           names = [:files, :env, :heroku, :docker] if names.empty?
           names.map { |name| const_get(camelize(name)).new }
+        end
+
+        def normalize(config)
+          config[:logs_database] = config[:database] if blank?(config[:logs_database])
+          config
         end
     end
 

--- a/lib/travis/config/env.rb
+++ b/lib/travis/config/env.rb
@@ -1,6 +1,6 @@
 module Travis
   class Config
-    class Env
+    class Env # TODO rename to keychain
       def load
         ENV['travis_config'] ? YAML.load(ENV['travis_config']) : {}
       end

--- a/lib/travis/config/helpers.rb
+++ b/lib/travis/config/helpers.rb
@@ -34,7 +34,7 @@ module Travis
       end
 
       def blank?(obj)
-        obj.respond_to?(:empty?) ? !!obj.empty? : !obj
+        obj.respond_to?(:empty?) ? obj.empty? : !obj
       end
 
       def camelize(string)

--- a/lib/travis/config/heroku.rb
+++ b/lib/travis/config/heroku.rb
@@ -4,7 +4,7 @@ require 'travis/config/heroku/memcached'
 
 module Travis
   class Config
-    class Heroku
+    class Heroku # TODO rename to EnvVar
       include Helpers
 
       def load
@@ -24,8 +24,7 @@ module Travis
         end
 
         def logs_database
-          config = Database.new(prefix: 'logs').config
-          config.empty? ? database : config
+          Database.new(prefix: 'logs').config
         end
 
         def amqp

--- a/spec/travis/config/heroku/database_spec.rb
+++ b/spec/travis/config/heroku/database_spec.rb
@@ -193,22 +193,7 @@ describe Travis::Config::Heroku, :Database do
     )
   end
 
-  it 'defaults logs_database to database if no other config is given' do
-    ENV['DATABASE_URL'] = 'postgres://username:password@hostname:1234/logs_database'
-
-    expect(config.logs_database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'logs_database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
-  end
-
-  it 'sets logs_database to nil if no DATABASE_URL and no LOGS_DATABASE_URL is given' do
+  it 'sets logs_database to nil if no LOGS_DATABASE_URL is given' do
     expect(config.logs_database).to be_nil
   end
 end


### PR DESCRIPTION
This fixes a bug that would overwrite `config.logs_database` (populated from keychain or config files) with `ENV['DATABASE_URL']`.