### PR TITLE
Support mock:// uri, which is used by the job-board test suite

### DIFF
--- a/lib/travis/config/heroku/url.rb
+++ b/lib/travis/config/heroku/url.rb
@@ -13,6 +13,7 @@ module Travis
         Generic  = Class.new(Base)
         Postgres = Class.new(Base)
         Redis    = Class.new(Base)
+        Mock     = Class.new(Base)
 
         class Amqp < Base
           alias :vhost :database

--- a/lib/travis/config/heroku/url.rb
+++ b/lib/travis/config/heroku/url.rb
@@ -13,7 +13,7 @@ module Travis
         Generic  = Class.new(Base)
         Postgres = Class.new(Base)
         Redis    = Class.new(Base)
-        Mock     = Class.new(Base)
+        Mock     = Class.new(Base) # e.g. mock:// used for Sequel::Mock
 
         class Amqp < Base
           alias :vhost :database


### PR DESCRIPTION
This is something that is supported by `sequel`: https://github.com/jeremyevans/sequel/blob/master/lib/sequel/adapters/mock.rb