### PR TITLE
Also pass along SSL param when using amqps://

### DIFF
--- a/lib/travis/config/heroku/url.rb
+++ b/lib/travis/config/heroku/url.rb
@@ -25,7 +25,7 @@ module Travis
 
         # The amqps:// protocol needs to also pass along that it has SSL enabled
         # for adapters such as march_hare
-        class Ampqs < Amqp
+        class Amqps < Amqp
           def ssl
             true
           end

--- a/lib/travis/config/heroku/url.rb
+++ b/lib/travis/config/heroku/url.rb
@@ -31,7 +31,7 @@ module Travis
           end
 
           def to_h
-            super.merge(ssl: true)
+            super.merge(ssl: ssl)
           end
         end
 

--- a/lib/travis/config/heroku/url.rb
+++ b/lib/travis/config/heroku/url.rb
@@ -25,7 +25,7 @@ module Travis
 
         # The amqps:// protocol needs to also pass along that it has SSL enabled
         # for adapters such as march_hare
-        class Ampqs < Ampq
+        class Ampqs < Amqp
           def ssl
             true
           end

--- a/lib/travis/config/heroku/url.rb
+++ b/lib/travis/config/heroku/url.rb
@@ -22,7 +22,18 @@ module Travis
             super.reject { |key, value| key == :database }.merge(vhost: vhost)
           end
         end
-        Amqps = Amqp
+
+        # The amqps:// protocol needs to also pass along that it has SSL enabled
+        # for adapters such as march_hare
+        class Ampqs < Ampq
+          def ssl
+            true
+          end
+
+          def to_h
+            super.merge(ssl: true)
+          end
+        end
 
         class << self
           def parse(url)

--- a/spec/travis/config/heroku/amqp_spec.rb
+++ b/spec/travis/config/heroku/amqp_spec.rb
@@ -29,6 +29,7 @@ describe Travis::Config::Heroku, :Amqp do
         vhost:    'vhost',
         username: 'username',
         password: 'password',
+        ssl:      true,
         prefetch: 1
       )
     end


### PR DESCRIPTION
As referenced over in https://github.com/travis-ci/travis-logs/pull/47 some RabbitMQ adapters want to be told if they're using ssl or tls. In that PR I patched it in at the app level (since it mostly applies to Enterprise 2.0) but this is a larger concern across apps, so this PR is looking to fix it at that level for the future. 

The idea here is that when we use the AMQPS protocol, we also output the ssl param. 

There are a few bits in my implementation that I don't feel great about, I'll mark them in the code. Love some feedback around those, if that feels appropriate or if there's maybe a more elegant way to go about it. :heart: 
