### PR TITLE
Remove logs_database normalization merge step

### DIFF
--- a/lib/travis/config.rb
+++ b/lib/travis/config.rb
@@ -18,7 +18,6 @@ module Travis
 
       def load(*names)
         config = load_from(*names)
-        config = normalize(config)
         new(config)
       end
 
@@ -33,11 +32,6 @@ module Travis
         def loaders(*names)
           names = [:files, :env, :heroku, :docker] if names.empty?
           names.map { |name| const_get(camelize(name)).new }
-        end
-
-        def normalize(config)
-          config[:logs_database] = config[:database] if blank?(config[:logs_database])
-          config
         end
     end
 

--- a/spec/travis/config_spec.rb
+++ b/spec/travis/config_spec.rb
@@ -70,8 +70,8 @@ describe Travis::Config do
       it { expect(config.logs_database.database).to eq 'keychain' }
     end
 
-    describe 'given logs_database is not defined anywhere it defaults to database' do
-      it { expect(config.logs_database.database).to eq 'database' }
+    describe 'given logs_database is not defined anywhere it does not default to database' do
+      it { expect(config.logs_database).to eq nil }
     end
   end
 end


### PR DESCRIPTION
It prevents downstream from defining a default `logs_database` key