### PR TITLE
use PGBOUNCER_PREPARED_STATEMENTS env var for all connections without…

### DIFF
--- a/lib/travis/config/heroku/database.rb
+++ b/lib/travis/config/heroku/database.rb
@@ -28,7 +28,7 @@ module Travis
           end
           
           def prepared_statements
-            env('PGBOUNCER_PREPARED_STATEMENTS').compact.first
+            ENV['PGBOUNCER_PREPARED_STATEMENTS']
           end
 
           def env(*keys)


### PR DESCRIPTION
… prefix

in order for pgbouncer to work correctly we need to disable prepared statements.
this patch ensures the `PGBOUNCER_PREPARED_STATEMENTS` env var is used.

prior to this patch, the logs database would require a `LOGS_PGBOUNCER_PREPARED_STATEMENTS` var.

refs https://github.com/travis-pro/team-teal/issues/1775