### PR TITLE
Generically read/write env vars

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--colour
+--tty
+--format documentation
+--require spec_helper

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --colour
 --tty
---format documentation
 --require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
+sudo: false
+dist: trusty
 language: ruby
 
 rvm:
-  - 2.0
   - 2.1
   - 2.2
-  - jruby-19mode
+  - 2.3
+  - 2.4
   - jruby-9
-
-sudo: false
 
 script: bundle exec rspec spec --color --format documentation --require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ gem 'hashr', '~> 2.0.0'
 group :test do
   gem 'rspec', '~> 3.0'
   gem 'mocha', '~> 1.1'
+  gem 'fakefs'
 end

--- a/lib/travis/config.rb
+++ b/lib/travis/config.rb
@@ -7,6 +7,7 @@ module Travis
     require 'travis/config/keychain'
     require 'travis/config/files'
     require 'travis/config/heroku'
+    require 'travis/config/serialize/env'
 
     include Hashr::Delegate::Conditional
 

--- a/lib/travis/config.rb
+++ b/lib/travis/config.rb
@@ -3,7 +3,7 @@ require 'hashr'
 module Travis
   class Config < Hashr
     require 'travis/config/docker'
-    require 'travis/config/env'
+    require 'travis/config/keychain'
     require 'travis/config/files'
     require 'travis/config/heroku'
 
@@ -30,7 +30,7 @@ module Travis
         end
 
         def loaders(*names)
-          names = [:files, :env, :heroku, :docker] if names.empty?
+          names = [:files, :keychain, :heroku, :docker] if names.empty?
           names.map { |name| const_get(camelize(name)).new }
         end
     end

--- a/lib/travis/config.rb
+++ b/lib/travis/config.rb
@@ -32,7 +32,7 @@ module Travis
         end
 
         def loaders(*names)
-          names = [:files, :keychain, :heroku, :docker] if names.empty?
+          names = [:files, :keychain, :heroku, :docker, :env] if names.empty?
           names.map { |name| const_get(camelize(name)).new(defaults) }
         end
     end

--- a/lib/travis/config.rb
+++ b/lib/travis/config.rb
@@ -3,6 +3,7 @@ require 'hashr'
 module Travis
   class Config < Hashr
     require 'travis/config/docker'
+    require 'travis/config/env'
     require 'travis/config/keychain'
     require 'travis/config/files'
     require 'travis/config/heroku'
@@ -31,7 +32,7 @@ module Travis
 
         def loaders(*names)
           names = [:files, :keychain, :heroku, :docker] if names.empty?
-          names.map { |name| const_get(camelize(name)).new }
+          names.map { |name| const_get(camelize(name)).new(defaults) }
         end
     end
 

--- a/lib/travis/config/docker.rb
+++ b/lib/travis/config/docker.rb
@@ -2,7 +2,7 @@ require 'travis/config/helpers'
 
 module Travis
   class Config
-    class Docker
+    class Docker < Struct.new(:defaults)
       include Helpers
 
       PATTERN = %r(tcp://(?<host>[^:]+):?(?<port>.*))

--- a/lib/travis/config/env.rb
+++ b/lib/travis/config/env.rb
@@ -1,0 +1,57 @@
+module Travis
+  class Config
+    class Env < Struct.new(:defaults)
+      class Vars < Struct.new(:defaults, :prefix)
+        TRUE  = /^(true|yes|on)$/
+        FALSE = /^(false|no|off)$/
+
+        def to_h
+          defaults.deep_merge(read_env(prefix.dup, defaults))
+        end
+
+        private
+
+          def read_env(prefix, defaults)
+            defaults.inject({}) do |config, (key, default)|
+              keys = prefix + [key]
+              value = default.is_a?(Hash) ? read_env(keys, default) : var(keys, default)
+              config.merge(key => value)
+            end
+          end
+
+          def var(keys, default)
+            key = keys.map(&:upcase).join('_')
+            value = ENV.fetch(key, default)
+            default.is_a?(Array) ? to_a(value) : cast(value, default)
+          end
+
+          def cast(value, default)
+            case value
+            when /^[\d]+\.[\d]+$/
+              value.to_f
+            when /^[\d]+$/
+              value.to_i
+            when TRUE
+              true
+            when FALSE
+              false
+            else
+              value
+            end
+          end
+
+          def to_a(value)
+            value.respond_to?(:split) ? value.split(',') : Array(value)
+          end
+      end
+
+      def self.prefix(prefix = nil)
+        prefix ? @prefix = prefix : @prefix
+      end
+
+      def load
+        Vars.new(defaults, [self.class.prefix.to_s.upcase]).to_h
+      end
+    end
+  end
+end

--- a/lib/travis/config/env.rb
+++ b/lib/travis/config/env.rb
@@ -1,31 +1,63 @@
 module Travis
   class Config
     class Env < Struct.new(:defaults)
+      class UnexpectedString < ArgumentError
+        MSG = 'Expected %s to be an array of hashes, but it is a string: %s'
+
+        def initialize(*args)
+          super(MSG % args)
+        end
+      end
+
       class Vars < Struct.new(:defaults, :prefix)
         TRUE  = /^(true|yes|on)$/
         FALSE = /^(false|no|off)$/
 
         def to_h
-          defaults.deep_merge(read_env(prefix.dup, defaults))
+          defaults.deep_merge(hash(ENV, prefix.dup, defaults))
         end
 
         private
 
-          def read_env(prefix, defaults)
+          def hash(env, prefix, defaults)
             defaults.inject({}) do |config, (key, default)|
-              keys = prefix + [key]
-              value = default.is_a?(Hash) ? read_env(keys, default) : var(keys, default)
-              config.merge(key => value)
+              config.merge key => obj(env, prefix + [key], default)
             end
           end
 
-          def var(keys, default)
-            key = keys.map(&:upcase).join('_')
-            value = ENV.fetch(key, default)
-            default.is_a?(Array) ? to_a(value) : cast(value, default)
+          def obj(env, keys, default)
+            case default
+            when Hash
+              hash(env, keys, default)
+            when Array
+              vars = array(env, keys, default)
+              vars.any? ? vars : var(env, keys, default)
+            else
+              var(env, keys, default)
+            end
           end
 
-          def cast(value, default)
+          def array(env, keys, defaults)
+            vars(env, keys, defaults).map.with_index do |var, ix|
+              obj(var, [], defaults[ix] || defaults[0] || {})
+            end
+          end
+
+          def var(env, key, default)
+            key = key.map(&:upcase).join('_')
+            value = env.fetch(key, default)
+            raise UnexpectedString.new(key, value) if value.is_a?(String) && hashes?(default)
+            default.is_a?(Array) ? split(value) : cast(value)
+          end
+
+          def vars(env, keys, default)
+            pattern = /^#{keys.map(&:upcase).join('_')}_([\d]+)_/
+            vars = env.select { |key, _| key =~ pattern }
+            vars = vars.map { |key, value| [key.sub(pattern, ''), value, $1] }
+            vars.group_by(&:pop).values.map(&:to_h)
+          end
+
+          def cast(value)
             case value
             when /^[\d]+\.[\d]+$/
               value.to_f
@@ -35,13 +67,20 @@ module Travis
               true
             when FALSE
               false
+            when ''
+              nil
             else
               value
             end
           end
 
-          def to_a(value)
-            value.respond_to?(:split) ? value.split(',') : Array(value)
+          def split(value)
+            values = value.respond_to?(:split) ? value.split(',') : Array(value)
+            values.map { |value| cast(value) }
+          end
+
+          def hashes?(obj)
+            obj.is_a?(Array) && obj.first.is_a?(Hash)
           end
       end
 

--- a/lib/travis/config/files.rb
+++ b/lib/travis/config/files.rb
@@ -6,15 +6,19 @@ module Travis
     class Files < Struct.new(:defaults)
       include Helpers
 
+      MSGS = {
+        empty: <<-msg.split("\n").map(&:strip).join("\n")
+          Warning: config in %{filename} has no data for current env %{env}.
+          If you are expecting config to be loaded from this file, please make sure
+          your config is indented under a key of the environment (%{env}).
+        msg
+      }
+
       def load
-        filenames.inject({}) do |config, filename|
-          file_config = load_file(filename)
-          if Config.env != "production" and file_config[Config.env].nil?
-            puts "Warning: config in #{filename} has no data for current env #{Config.env}"
-            puts "If you are expecting config to be loaded from this file, please make sure"
-            puts "your config is indented under a key of the environment (#{Config.env})"
-          end
-          deep_merge(config, file_config[Config.env] || {})
+        filenames.inject({}) do |result, filename|
+          config = load_file(filename)
+          warn_empty(filename) if warn_empty? && config[env].nil?
+          deep_merge(result, config[env] || {})
         end
       end
 
@@ -27,8 +31,20 @@ module Travis
           {}
         end
 
+        def warn_empty(filename)
+          puts MSGS[:empty] % { filename: filename, env: env }
+        end
+
+        def warn_empty?
+          !%w(production test).include?(Config.env)
+        end
+
         def filenames
-          @filenames ||= Dir['config/{travis.yml,travis/*.yml}'].sort
+          @filenames ||= Dir['config/travis.yml'] + Dir['config/travis/*.yml'].sort
+        end
+
+        def env
+          Config.env
         end
     end
   end

--- a/lib/travis/config/files.rb
+++ b/lib/travis/config/files.rb
@@ -3,7 +3,7 @@ require 'travis/config/helpers'
 
 module Travis
   class Config
-    class Files
+    class Files < Struct.new(:defaults)
       include Helpers
 
       def load

--- a/lib/travis/config/heroku.rb
+++ b/lib/travis/config/heroku.rb
@@ -1,10 +1,10 @@
 require 'travis/config/helpers'
-require 'travis/config/heroku/database'
-require 'travis/config/heroku/memcached'
-
 module Travis
   class Config
-    class Heroku # TODO rename to EnvVar
+    class Heroku < Struct.new(:defaults)
+      require 'travis/config/heroku/database'
+      require 'travis/config/heroku/memcached'
+
       include Helpers
 
       def load

--- a/lib/travis/config/keychain.rb
+++ b/lib/travis/config/keychain.rb
@@ -1,6 +1,6 @@
 module Travis
   class Config
-    class Env # TODO rename to keychain
+    class Keychain
       def load
         ENV['travis_config'] ? YAML.load(ENV['travis_config']) : {}
       end

--- a/lib/travis/config/keychain.rb
+++ b/lib/travis/config/keychain.rb
@@ -1,6 +1,6 @@
 module Travis
   class Config
-    class Keychain
+    class Keychain < Struct.new(:defaults)
       def load
         ENV['travis_config'] ? YAML.load(ENV['travis_config']) : {}
       end

--- a/lib/travis/config/serialize/env.rb
+++ b/lib/travis/config/serialize/env.rb
@@ -1,0 +1,45 @@
+module Travis
+  class Config
+    module Serialize
+      class Env < Struct.new(:config, :opts)
+        attr_reader :config, :opts
+
+        def initialize(config, opts = {})
+          @config = config
+          @opts = opts
+        end
+
+        def apply
+          vars.to_a.map { |pair| pair.join('=') }
+        end
+
+        private
+
+          def vars
+            collect(Array(prefix), config).map do |keys, value|
+              [keys.map(&:to_s).map(&:upcase).join('_'), value.to_s]
+            end.to_h
+          end
+
+          def collect(keys, config)
+            compact(config).inject({}) do |result, (key, value)|
+              case value
+              when Hash
+                result.merge collect(keys + [key], value)
+              else
+                result.merge [[keys + [key], value]].to_h
+              end
+            end
+          end
+
+          def compact(hash)
+            hash.reject { |_, value| value.nil? }.to_h
+          end
+
+          def prefix
+            opts[:prefix]
+          end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,15 +3,20 @@ ENV['DYNO'] = 'travis-config/specs'
 
 require 'mocha'
 require 'travis/config'
+require 'support/env'
 
 module Travis::Test
   class Config < Travis::Config
-    define amqp: { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 }
-    define database: { adapter: 'postgresql', database: 'test', encoding: 'unicode' }
+    define amqp:     { username: 'guest', password: 'guest', host: 'localhost', prefetch: 1 },
+           database: { adapter: 'postgresql', database: 'test', encoding: 'unicode' },
+           redis:    { url: 'redis://localhost:6379' }
+
+    Env.prefix :travis
   end
 end
 
-RSpec.configure do |config|
-  config.mock_with :mocha
+RSpec.configure do |c|
+  c.mock_with :mocha
+  c.include Support::Env
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ ENV['DYNO'] = 'travis-config/specs'
 require 'mocha'
 require 'travis/config'
 require 'support/env'
+require 'support/fakefs'
 
 module Travis::Test
   class Config < Travis::Config
@@ -18,5 +19,6 @@ end
 RSpec.configure do |c|
   c.mock_with :mocha
   c.include Support::Env
+  c.include Support::FakeFs
 end
 

--- a/spec/support/env.rb
+++ b/spec/support/env.rb
@@ -7,12 +7,14 @@ module Support
     module ClassMethods
       def env(vars)
         before { define_env(vars) }
-        after  { undefine_env(vars) }
       end
     end
 
     def define_env(vars)
-      vars.each { |key, value| ENV[key.to_s] = value.to_s }
+      vars.each do |key, value|
+        ENV[key.to_s] = value.is_a?(Proc) ? instance_exec(&value).to_s : value.to_s
+      end
+      self.class.after { undefine_env(vars) }
     end
 
     def undefine_env(vars)

--- a/spec/support/env.rb
+++ b/spec/support/env.rb
@@ -1,0 +1,22 @@
+module Support
+  module Env
+    def self.included(base)
+      base.send(:extend, ClassMethods)
+    end
+
+    module ClassMethods
+      def env(vars)
+        before { define_env(vars) }
+        after  { undefine_env(vars) }
+      end
+    end
+
+    def define_env(vars)
+      vars.each { |key, value| ENV[key.to_s] = value.to_s }
+    end
+
+    def undefine_env(vars)
+      vars.each { |key, _| ENV.delete(key.to_s) }
+    end
+  end
+end

--- a/spec/support/fakefs.rb
+++ b/spec/support/fakefs.rb
@@ -1,0 +1,27 @@
+require 'pp' # https://github.com/fakefs/fakefs#fakefs-vs-pp-----typeerror-superclass-mismatch-for-class-file
+require 'fakefs/safe'
+require 'fileutils'
+
+module Support
+  module FakeFs
+    def self.included(base)
+      base.send(:extend, ClassMethods)
+      base.before { FakeFS.activate! }
+      base.after  { FakeFS.deactivate! }
+      base.after  { FakeFS::FileSystem.clear }
+    end
+
+    module ClassMethods
+      def dir(dir)
+        before { FileUtils.mkdir_p(dir) }
+        after  { FileUtils.rm_rf(dir) }
+      end
+
+      def file(path, content)
+        before { FileUtils.mkdir_p(File.dirname(path)) }
+        before { File.write(path, content) }
+        after  { FileUtils.rm_rf(File.dirname(path)) }
+      end
+    end
+  end
+end

--- a/spec/travis/config/docker_spec.rb
+++ b/spec/travis/config/docker_spec.rb
@@ -1,10 +1,8 @@
 describe Travis::Config::Docker do
   let(:config) { Travis::Test::Config.load(:docker) }
-  let(:vars)   { %w(POSTGRESQL_PORT RABBITMQ_PORT REDIS_PORT) }
-  after        { vars.each { |key| ENV.delete(key) } }
 
   describe 'loads POSTGRESQL_PORT to config.database' do
-    before { ENV['POSTGRESQL_PORT'] = 'tcp://172.17.0.11:5432' }
+    env POSTGRESQL_PORT: 'tcp://172.17.0.11:5432'
 
     it 'loads host and port from the env var' do
       expect(config.database.values_at(:host, :port)).to eq(['172.17.0.11', '5432'])
@@ -16,7 +14,7 @@ describe Travis::Config::Docker do
   end
 
   describe 'loads RABBITMQ_PORT to config.amqp' do
-    before { ENV['RABBITMQ_PORT'] = 'tcp://172.17.0.11:5672' }
+    env RABBITMQ_PORT: 'tcp://172.17.0.11:5672'
 
     it 'loads host and port from the env var' do
       expect(config.amqp.values_at(:host, :port)).to eq(['172.17.0.11', '5672'])
@@ -28,7 +26,7 @@ describe Travis::Config::Docker do
   end
 
   describe 'loads REDIS_PORT' do
-    before { ENV['REDIS_PORT'] = 'tcp://172.17.0.7:6379' }
+    env REDIS_PORT: 'tcp://172.17.0.7:6379'
 
     it 'loads the port to redis.url' do
       expect(config.redis.to_h).to eq({ url: 'tcp://172.17.0.7:6379' })

--- a/spec/travis/config/env_spec.rb
+++ b/spec/travis/config/env_spec.rb
@@ -1,0 +1,57 @@
+module Travis::Test::Env
+  class Config < Travis::Config
+    define database: { adapter: nil, variables: { statement_timeout: nil } },
+           hash:    { under_scored: nil, nested: { foo: nil } },
+           array:   [],
+           integer: nil,
+           float:   nil,
+           true:    nil,
+           yes:     nil,
+           on:      nil,
+           false:   nil,
+           no:      nil,
+           off:     nil,
+           nil:     nil
+
+
+    Env.prefix :travis
+  end
+end
+
+describe Travis::Config::Env do
+  let(:config) { Travis::Test::Env::Config.load(:env) }
+
+  describe 'cast' do
+    env TRAVIS_HASH_UNDER_SCORED: 'under_scored',
+        TRAVIS_HASH_NESTED_FOO: 'foo',
+        TRAVIS_INTEGER: '10',
+        TRAVIS_FLOAT: '10.0',
+        TRAVIS_TRUE: 'true',
+        TRAVIS_YES: 'yes',
+        TRAVIS_ON: 'on',
+        TRAVIS_FALSE: 'false',
+        TRAVIS_NO: 'no',
+        TRAVIS_OFF: 'off',
+        TRVIS_NIL: nil
+
+    it { expect(config.hash.under_scored).to eq 'under_scored' }
+    it { expect(config.hash.nested.foo).to eq 'foo' }
+    it { expect(config.integer).to be 10 }
+    it { expect(config.float).to be 10.0 }
+    it { expect(config.true).to be true }
+    it { expect(config.yes).to be true }
+    it { expect(config.on).to be true }
+    it { expect(config.false).to be false }
+    it { expect(config.no).to be false }
+    it { expect(config.off).to be false }
+    it { expect(config.nil).to be nil }
+  end
+
+  describe 'database' do
+    env TRAVIS_DATABASE_ADAPTER: 'postgres',
+        TRAVIS_DATABASE_VARIABLES_STATEMENT_TIMEOUT: 10_000
+
+    it { expect(config.database.adapter).to eq 'postgres' }
+    it { expect(config.database.variables.statement_timeout).to eq 10_000 }
+  end
+end

--- a/spec/travis/config/heroku/amqp_spec.rb
+++ b/spec/travis/config/heroku/amqp_spec.rb
@@ -1,8 +1,7 @@
 describe Travis::Config::Heroku, :Amqp do
   let(:config) { Travis::Test::Config.load(:heroku) }
 
-  before       { ENV['RABBITMQ_URL'] = url }
-  after        { ENV.delete('RABBITMQ_URL') }
+  env RABBITMQ_URL: -> { url }
 
   describe 'using amqp as a protocol' do
     let(:url) { 'amqp://username:password@hostname:1234/vhost' }

--- a/spec/travis/config/heroku/database_spec.rb
+++ b/spec/travis/config/heroku/database_spec.rb
@@ -1,199 +1,222 @@
 describe Travis::Config::Heroku, :Database do
   let(:config) { Travis::Test::Config.load(:heroku) }
-  before       { ENV['DYNO'] = 'app_name' }
-  after        { ENV.clear }
+  env DYNO: 'app_name'
 
-  it 'loads a TRAVIS_DATABASE_URL with a port' do
-    ENV['TRAVIS_DATABASE_URL'] = 'postgres://username:password@hostname:1234/database'
+  describe 'loads a TRAVIS_DATABASE_URL with a port' do
+    env TRAVIS_DATABASE_URL: 'postgres://username:password@hostname:1234/database'
 
-    expect(config.database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads a DATABASE_URL with a port' do
-    ENV['DATABASE_URL'] = 'postgres://username:password@hostname:1234/database'
+  describe 'loads a DATABASE_URL with a port' do
+    env DATABASE_URL: 'postgres://username:password@hostname:1234/database'
 
-    expect(config.database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads a DATABASE_URL without a port' do
-    ENV['DATABASE_URL'] = 'postgres://username:password@hostname/database'
+  describe 'loads a DATABASE_URL without a port' do
+    env DATABASE_URL: 'postgres://username:password@hostname/database'
 
-    expect(config.database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      database:  'database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      variables:  { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        database:  'database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        variables:  { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads TRAVIS_DATABASE_POOL_SIZE' do
-    ENV['TRAVIS_DATABASE_URL'] = 'postgres://username:password@hostname:1234/database'
-    ENV['TRAVIS_DATABASE_POOL_SIZE'] = '25'
+  describe 'loads TRAVIS_DATABASE_POOL_SIZE' do
+    env TRAVIS_DATABASE_URL: 'postgres://username:password@hostname:1234/database'
+    env TRAVIS_DATABASE_POOL_SIZE: '25'
 
-    expect(config.database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      pool:      25,
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        pool:      25,
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads DATABASE_POOL_SIZE' do
-    ENV['DATABASE_URL'] = 'postgres://username:password@hostname:1234/database'
-    ENV['DATABASE_POOL_SIZE'] = '25'
+  describe 'loads DATABASE_POOL_SIZE' do
+    env DATABASE_URL: 'postgres://username:password@hostname:1234/database'
+    env DATABASE_POOL_SIZE: '25'
 
-    expect(config.database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      pool:      25,
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        pool:      25,
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads DB_POOL' do
-    ENV['DATABASE_URL'] = 'postgres://username:password@hostname:1234/database'
-    ENV['DB_POOL'] = '25'
+  describe 'loads DB_POOL' do
+    env DATABASE_URL: 'postgres://username:password@hostname:1234/database'
+    env DB_POOL: '25'
 
-    expect(config.database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      pool:      25,
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        pool:      25,
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads a TRAVIS_LOGS_DATABASE_URL with a port' do
-    ENV['TRAVIS_LOGS_DATABASE_URL'] = 'postgres://username:password@hostname:1234/logs_database'
+  describe 'loads a TRAVIS_LOGS_DATABASE_URL with a port' do
+    env TRAVIS_LOGS_DATABASE_URL: 'postgres://username:password@hostname:1234/logs_database'
 
-    expect(config.logs_database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'logs_database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.logs_database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'logs_database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads a LOGS_DATABASE_URL with a port' do
-    ENV['LOGS_DATABASE_URL'] = 'postgres://username:password@hostname:1234/logs_database'
+  describe 'loads a LOGS_DATABASE_URL with a port' do
+    env LOGS_DATABASE_URL: 'postgres://username:password@hostname:1234/logs_database'
 
-    expect(config.logs_database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'logs_database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.logs_database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'logs_database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads a LOGS_DATABASE_URL without a port' do
-    ENV['LOGS_DATABASE_URL'] = 'postgres://username:password@hostname/logs_database'
+  describe 'loads a LOGS_DATABASE_URL without a port' do
+    env LOGS_DATABASE_URL: 'postgres://username:password@hostname/logs_database'
 
-    expect(config.logs_database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      database:  'logs_database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.logs_database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        database:  'logs_database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads LOGS_DB_POOL' do
-    ENV['LOGS_DATABASE_URL'] = 'postgres://username:password@hostname:1234/logs_database'
-    ENV['LOGS_DB_POOL'] = '1'
+  describe 'loads LOGS_DB_POOL' do
+    env LOGS_DATABASE_URL: 'postgres://username:password@hostname:1234/logs_database'
+    env LOGS_DB_POOL: '1'
 
-    expect(config.logs_database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'logs_database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      pool:      1,
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.logs_database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'logs_database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        pool:      1,
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads TRAVIS_LOGS_DATABASE_POOL_SIZE' do
-    ENV['TRAVIS_LOGS_DATABASE_URL'] = 'postgres://username:password@hostname:1234/logs_database'
-    ENV['TRAVIS_LOGS_DATABASE_POOL_SIZE'] = '25'
+  describe 'loads TRAVIS_LOGS_DATABASE_POOL_SIZE' do
+    env TRAVIS_LOGS_DATABASE_URL: 'postgres://username:password@hostname:1234/logs_database'
+    env TRAVIS_LOGS_DATABASE_POOL_SIZE: '25'
 
-    expect(config.logs_database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'logs_database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      pool:      25,
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.logs_database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'logs_database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        pool:      25,
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'loads LOGS_DATABASE_POOL_SIZE' do
-    ENV['LOGS_DATABASE_URL'] = 'postgres://username:password@hostname:1234/logs_database'
-    ENV['LOGS_DATABASE_POOL_SIZE'] = '25'
+  describe 'loads LOGS_DATABASE_POOL_SIZE' do
+    env LOGS_DATABASE_URL: 'postgres://username:password@hostname:1234/logs_database'
+    env LOGS_DATABASE_POOL_SIZE: '25'
 
-    expect(config.logs_database.to_h).to eq(
-      adapter:   'postgresql',
-      host:      'hostname',
-      port:      1234,
-      database:  'logs_database',
-      username:  'username',
-      password:  'password',
-      encoding:  'unicode',
-      pool:      25,
-      variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
-    )
+    it do
+      expect(config.logs_database.to_h).to eq(
+        adapter:   'postgresql',
+        host:      'hostname',
+        port:      1234,
+        database:  'logs_database',
+        username:  'username',
+        password:  'password',
+        encoding:  'unicode',
+        pool:      25,
+        variables: { application_name: 'travis-config/specs', statement_timeout: 10_000 }
+      )
+    end
   end
 
-  it 'sets logs_database to nil if no LOGS_DATABASE_URL is given' do
-    expect(config.logs_database).to be_nil
+  describe 'sets logs_database to nil if no LOGS_DATABASE_URL is given' do
+    it { expect(config.logs_database).to be_nil }
   end
 end

--- a/spec/travis/config/heroku/memcached_spec.rb
+++ b/spec/travis/config/heroku/memcached_spec.rb
@@ -5,8 +5,7 @@ describe Travis::Config::Heroku, :Memcached do
   let(:password) { 'password' }
 
   [:servers, :username, :password].each do |key|
-    before { ENV["MEMCACHED_#{key.to_s.upcase}"] = send(key) }
-    after  { ENV.delete("MEMCACHED_#{key.to_s.upcase}") }
+    env "MEMCACHED_#{key.to_s.upcase}" => -> { send(key) }
   end
 
   it 'loads a MEMCACHED_SERVERS' do

--- a/spec/travis/config/heroku/redis_spec.rb
+++ b/spec/travis/config/heroku/redis_spec.rb
@@ -2,8 +2,7 @@ describe Travis::Config::Heroku, :Redis do
   let(:config) { Travis::Test::Config.load(:heroku) }
   let(:url)    { 'redis://username:password@hostname:1234/database' }
 
-  before       { ENV['REDIS_URL'] = url }
-  after        { ENV.delete('REDIS_URL') }
+  env REDIS_URL: -> { url }
 
   it 'loads a REDIS_URL' do
     expect(config.redis.to_h).to eq(url: url)

--- a/spec/travis/config/heroku/sentry_spec.rb
+++ b/spec/travis/config/heroku/sentry_spec.rb
@@ -2,16 +2,13 @@ describe Travis::Config::Heroku, :Sentry do
   let(:config) { Travis::Test::Config.load(:heroku) }
   let(:dsn)    { 'http://foo:bar@app.getsentry.com/1' }
 
-  before       { ENV[key] = dsn }
-  after        { ENV.delete('SENTRY_DSN') }
-
   describe 'loads a SENTRY_DSN' do
-    let(:key)  { 'SENTRY_DSN' }
+    env SENTRY_DSN: -> { dsn }
     it { expect(config.sentry.to_h).to eq(dsn: dsn) }
   end
 
   describe 'loads a TRAVIS_SENTRY_DSN' do
-    let(:key)  { 'TRAVIS_SENTRY_DSN' }
+    env TRAVIS_SENTRY_DSN: -> { dsn }
     it { expect(config.sentry.to_h).to eq(dsn: dsn) }
   end
 end

--- a/spec/travis/config/serialize/env_spec.rb
+++ b/spec/travis/config/serialize/env_spec.rb
@@ -1,0 +1,17 @@
+describe Travis::Config::Serialize::Env do
+  let(:config) do
+    {
+      foo: { bar: :baz },
+      true: true,
+      false: false,
+      nil: nil
+    }
+  end
+
+  subject { described_class.new(config, prefix: 'travis').apply }
+
+  it { should include 'TRAVIS_FOO_BAR=baz' }
+  it { should include 'TRAVIS_TRUE=true' }
+  it { should include 'TRAVIS_FALSE=false' }
+  it { should_not include 'TRAVIS_NIL=' }
+end

--- a/spec/travis/config_spec.rb
+++ b/spec/travis/config_spec.rb
@@ -24,10 +24,9 @@ describe Travis::Config do
   end
 
   describe 'reads custom config files' do
-    before { Dir.stubs(:[]).returns ['config/travis.yml', 'config/travis/foo.yml', 'config/travis/bar.yml'] }
-    before { YAML.stubs(:load_file).with('config/travis.yml').returns('test' => { 'travis' => 'travis', 'shared' => 'travis' }) }
-    before { YAML.stubs(:load_file).with('config/travis/foo.yml').returns('test' => { 'foo' => 'foo' }) }
-    before { YAML.stubs(:load_file).with('config/travis/bar.yml').returns('test' => { 'bar' => 'bar', 'shared' => 'bar' }) }
+    file 'config/travis.yml',     YAML.dump('test' => { 'travis' => 'travis', 'shared' => 'travis' })
+    file 'config/travis/foo.yml', YAML.dump('test' => { 'foo' => 'foo' })
+    file 'config/travis/bar.yml', YAML.dump('test' => { 'bar' => 'bar', 'shared' => 'bar' })
 
     it { expect(config.travis).to eq('travis') }
     it { expect(config.foo).to eq('foo') }
@@ -44,9 +43,8 @@ describe Travis::Config do
     env DATABASE_URL: 'postgres://username:password@hostname:1234/database'
 
     describe 'given logs_database is defined in a config file' do
-      before { Dir.stubs(:[]).returns ['config/travis.yml'] }
-      before { YAML.stubs(:load_file).with('config/travis.yml').returns('test' => { 'logs_database' => { 'database' => 'config_file' } }) }
-      it { expect(config.logs_database.database).to eq 'config_file' }
+      file 'config/travis.yml', YAML.dump('test' => { 'logs_database' => { 'database' => 'from_file' } })
+      it { expect(config.logs_database.database).to eq 'from_file' }
     end
 
     describe 'given logs_database is defined in the keychain' do

--- a/spec/travis/config_spec.rb
+++ b/spec/travis/config_spec.rb
@@ -1,5 +1,5 @@
 describe Travis::Config do
-  let(:config) { Travis::Test::Config.load(:files, :env, :heroku, :docker) }
+  let(:config) { Travis::Test::Config.load(:files, :keychain, :heroku, :docker) }
 
   describe 'Hashr behaviour' do
     after :each do

--- a/spec/travis/config_spec.rb
+++ b/spec/travis/config_spec.rb
@@ -6,67 +6,51 @@ describe Travis::Config do
       ENV.delete('travis_config')
     end
 
-    it 'is a Hashr instance' do
-      expect(config).to be_kind_of(Hashr)
+    it { expect(config).to be_kind_of(Hashr) }
+
+    describe 'returns Hashr instances on subkeys' do
+      before { ENV['travis_config'] = YAML.dump('redis' => { 'url' => 'redis://localhost:6379' }) }
+      it { expect(config.redis).to be_kind_of(Hashr) }
     end
 
-    it 'returns Hashr instances on subkeys' do
-      ENV['travis_config'] = YAML.dump('redis' => { 'url' => 'redis://localhost:6379' })
-      expect(config.redis).to be_kind_of(Hashr)
+    describe 'returns Hashr instances on subkeys that were set to Ruby Hashes' do
+      before { config.foo = { :bar => { :baz => 'baz' } } }
+      it { expect(config.foo.bar).to be_kind_of(Hashr) }
     end
 
-    it 'returns Hashr instances on subkeys that were set to Ruby Hashes' do
-      config.foo = { :bar => { :baz => 'baz' } }
-      expect(config.foo.bar).to be_kind_of(Hashr)
-    end
-
-    it 'can access nested keys' do
-      expect(config.amqp.username).to eq('guest')
+    describe 'can access nested keys' do
+      it { expect(config.amqp.username).to eq('guest') }
     end
   end
 
   describe 'reads custom config files' do
-    before :each do
-      Dir.stubs(:[]).returns ['config/travis.yml', 'config/travis/foo.yml', 'config/travis/bar.yml']
-      YAML.stubs(:load_file).with('config/travis.yml').returns('test' => { 'travis' => 'travis', 'shared' => 'travis' })
-      YAML.stubs(:load_file).with('config/travis/foo.yml').returns('test' => { 'foo' => 'foo' })
-      YAML.stubs(:load_file).with('config/travis/bar.yml').returns('test' => { 'bar' => 'bar', 'shared' => 'bar' })
-    end
+    before { Dir.stubs(:[]).returns ['config/travis.yml', 'config/travis/foo.yml', 'config/travis/bar.yml'] }
+    before { YAML.stubs(:load_file).with('config/travis.yml').returns('test' => { 'travis' => 'travis', 'shared' => 'travis' }) }
+    before { YAML.stubs(:load_file).with('config/travis/foo.yml').returns('test' => { 'foo' => 'foo' }) }
+    before { YAML.stubs(:load_file).with('config/travis/bar.yml').returns('test' => { 'bar' => 'bar', 'shared' => 'bar' }) }
 
-    it 'still reads the default config file' do
-      expect(config.travis).to eq('travis')
-    end
-
-    it 'merges custom files' do
-      expect(config.foo).to eq('foo')
-      expect(config.bar).to eq('bar')
-    end
-
-    it 'overwrites previously set values with values loaded later' do
-      expect(config.shared).to eq('bar')
-    end
+    it { expect(config.travis).to eq('travis') }
+    it { expect(config.foo).to eq('foo') }
+    it { expect(config.bar).to eq('bar') }
+    it { expect(config.shared).to eq('bar') }
   end
 
-  it 'deep symbolizes arrays, too' do
-    config = Travis::Config.new('queues' => [{ 'slug' => 'rails/rails', 'queue' => 'rails' }])
-    expect(config.queues.first.values_at(:slug, :queue)).to eq(['rails/rails', 'rails'])
+  describe 'deep symbolizes arrays, too' do
+    let(:config) { Travis::Config.new('queues' => [{ 'slug' => 'rails/rails', 'queue' => 'rails' }]) }
+    it { expect(config.queues.first.values_at(:slug, :queue)).to eq(['rails/rails', 'rails']) }
   end
 
   describe 'logs_database config' do
-    before { ENV['DATABASE_URL'] = 'postgres://username:password@hostname:1234/database' }
-    after  { ENV['DATABASE_URL'] = nil }
+    env DATABASE_URL: 'postgres://username:password@hostname:1234/database'
 
     describe 'given logs_database is defined in a config file' do
-      before do
-        Dir.stubs(:[]).returns ['config/travis.yml']
-        YAML.stubs(:load_file).with('config/travis.yml').returns('test' => { 'logs_database' => { 'database' => 'config_file' } })
-      end
+      before { Dir.stubs(:[]).returns ['config/travis.yml'] }
+      before { YAML.stubs(:load_file).with('config/travis.yml').returns('test' => { 'logs_database' => { 'database' => 'config_file' } }) }
       it { expect(config.logs_database.database).to eq 'config_file' }
     end
 
     describe 'given logs_database is defined in the keychain' do
-      before { ENV['travis_config'] = YAML.dump('logs_database' => { 'database' => 'keychain' }) }
-      after  { ENV['travis_config'] = nil }
+      env travis_config: YAML.dump('logs_database' => { 'database' => 'keychain' })
       it { expect(config.logs_database.database).to eq 'keychain' }
     end
 


### PR DESCRIPTION
The purpose of this is the ability to specify env vars that match the naming of nested defaults, as defined on the `Config` class. 

See [this spec](https://github.com/travis-ci/travis-config/blob/de0a69dbf967fbb399ab5e63750850cfcb514b0a/spec/travis/config/env_spec.rb) for an overview of supported values/structures.

This also renames the [current `Config::Env` class](https://github.com/travis-ci/travis-config/blob/master/lib/travis/config/env.rb) to `Config::Keychain`, which seems a better naming anyway.

I'm not aware of any apps that specify custom loaders when calling `Config.load` [here](https://github.com/travis-ci/travis-config/blob/master/lib/travis/config.rb#L19). We should double check before we merge this though, as we might then need to use the new loader name `keychain` there, too.