### PR TITLE
Loosen the hashr dependency a bit

### DIFF
--- a/travis-config.gemspec
+++ b/travis-config.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.rubyforge_project = '[none]'
 
-  s.add_dependency 'hashr', '~> 2.0.0'
+  s.add_dependency 'hashr', '~> 2.0'
 end


### PR DESCRIPTION
This is a preventative step, as the latest release of hashr `2.0.1` will still work.