### PR TITLE
fix(docker): use "redis" schema in redis url

### DIFF
--- a/lib/travis/config/docker.rb
+++ b/lib/travis/config/docker.rb
@@ -22,7 +22,7 @@ module Travis
         end
 
         def redis
-          { url: ENV['REDIS_PORT'] } if ENV['REDIS_PORT']
+          { url: ENV['REDIS_PORT'].sub(%r(\Atcp(?=://)), 'redis') } if ENV['REDIS_PORT']
         end
 
         def parse(url)

--- a/spec/travis/config/docker_spec.rb
+++ b/spec/travis/config/docker_spec.rb
@@ -28,8 +28,8 @@ describe Travis::Config::Docker do
   describe 'loads REDIS_PORT' do
     env REDIS_PORT: 'tcp://172.17.0.7:6379'
 
-    it 'loads the port to redis.url' do
-      expect(config.redis.to_h).to eq({ url: 'tcp://172.17.0.7:6379' })
+    it 'loads the port to redis.url as a redis:// url' do
+      expect(config.redis.to_h).to eq({ url: 'redis://172.17.0.7:6379' })
     end
   end
 end


### PR DESCRIPTION
This is just a rebase of #2. I run into the same issue and saw there was already this old PR that fixed it.