### PR TITLE
Do not overwrite db defaults given by the client with our own defaults

### DIFF
--- a/lib/travis/config/heroku.rb
+++ b/lib/travis/config/heroku.rb
@@ -22,15 +22,15 @@ module Travis
       private
 
         def database
-          Database.new.config
+          Database.new(db_defaults).config
         end
 
         def logs_database
-          Database.new(prefix: 'logs').config
+          Database.new(db_defaults, prefix: 'logs').config
         end
 
         def logs_readonly_database
-          Database.new(prefix: 'logs_readonly').config
+          Database.new(db_defaults, prefix: 'logs_readonly').config
         end
 
         def amqp
@@ -49,6 +49,10 @@ module Travis
           Memcached.new.config
         end
 
+        def db_defaults
+          defaults[:database] || {}
+        end
+
         def amqp_url
           ENV['TRAVIS_RABBITMQ_URL'] || ENV['RABBITMQ_URL'] || ENV['CLOUDAMQP_URL'] || ENV['RABBITMQ_BIGWIG_URL']
         end
@@ -56,7 +60,7 @@ module Travis
         def redis_url
           ENV['TRAVIS_REDIS_URL'] || ENV['REDIS_URL']
         end
-      
+
         def redis_pool_size
           ENV['TRAVIS_REDIS_POOL_SIZE'] || ENV['REDIS_POOL_SIZE']
         end

--- a/lib/travis/config/heroku/database.rb
+++ b/lib/travis/config/heroku/database.rb
@@ -3,7 +3,7 @@ require 'travis/config/heroku/url'
 module Travis
   class Config
     class Heroku
-      class Database < Struct.new(:options)
+      class Database < Struct.new(:defaults, :options)
         include Helpers
 
         VARIABLES = { application_name: ENV['DYNO'] || $0, statement_timeout: 10_000 }
@@ -11,7 +11,7 @@ module Travis
 
         def config
           config = compact(Url.parse(url).to_h)
-          config = deep_merge(DEFAULTS, config) unless config.empty?
+          config = deep_merge(deep_merge(DEFAULTS, defaults), config) unless config.empty?
           config[:pool] = pool.to_i if pool
           config[:prepared_statements] = prepared_statements != 'false' if prepared_statements
           config
@@ -26,7 +26,7 @@ module Travis
           def pool
             env('DATABASE_POOL_SIZE', 'DB_POOL').compact.first
           end
-          
+
           def prepared_statements
             ENV['PGBOUNCER_PREPARED_STATEMENTS']
           end

--- a/spec/travis/config/heroku/database_spec.rb
+++ b/spec/travis/config/heroku/database_spec.rb
@@ -219,4 +219,10 @@ describe Travis::Config::Heroku, :Database do
   describe 'sets logs_database to nil if no LOGS_DATABASE_URL is given' do
     it { expect(config.logs_database).to be_nil }
   end
+
+  describe 'does not overwrite variables given as defaults' do
+    before { Travis::Test::Config.defaults[:database][:variables] = { statement_timeout: 1 } }
+    env TRAVIS_DATABASE_URL: 'postgres://username:password@hostname:1234/database'
+    it { expect(config.database.variables.statement_timeout).to eq 1 }
+  end
 end


### PR DESCRIPTION
So far, if we have a `DATABASE_URL` on Heroku we force connection variables to be `statement_timeout: 10s` and `application_name: ENV['DYNO']`, calling these `DEFAULTS`,
even if the app specifies a different default. 

This change makes it so that the application's default takes precedence over our own (i.e. travis-config's) default.